### PR TITLE
ISR-222 - Fixes when ansible become is being used in a hosts file, become=false…

### DIFF
--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -39,6 +39,8 @@
     - "{{ prometheus_config_dir }}/file_sd"
 
 - name: Get prometheus binary
+  vars:
+    ansible_become: False
   when:
     - prometheus_binary_local_dir | length == 0
     - not prometheus_skip_install
@@ -68,31 +70,31 @@
       delegate_to: localhost
       check_mode: false
 
-    - name: Propagate official prometheus and promtool binaries
-      ansible.builtin.copy:
-        src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
-        dest: "{{ _prometheus_binary_install_dir }}/{{ item }}"
-        mode: 0755
-        owner: root
-        group: root
-      with_items:
-        - prometheus
-        - promtool
-      notify:
-        - restart prometheus
+- name: Propagate official prometheus and promtool binaries
+  ansible.builtin.copy:
+    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}"
+    dest: "{{ _prometheus_binary_install_dir }}/{{ item }}"
+    mode: 0755
+    owner: root
+    group: root
+    with_items:
+      - prometheus
+      - promtool
+    notify:
+      - restart prometheus
 
-    - name: Propagate official console templates
-      ansible.builtin.copy:
-        src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}/"
-        dest: "{{ prometheus_config_dir }}/{{ item }}/"
-        mode: 0644
-        owner: root
-        group: root
-      with_items:
-        - console_libraries
-        - consoles
-      notify:
-        - restart prometheus
+- name: Propagate official console templates
+  ansible.builtin.copy:
+    src: "/tmp/prometheus-{{ prometheus_version }}.linux-{{ go_arch }}/{{ item }}/"
+    dest: "{{ prometheus_config_dir }}/{{ item }}/"
+    mode: 0644
+    owner: root
+    group: root
+    with_items:
+      - console_libraries
+      - consoles
+    notify:
+      - restart prometheus
 
 - name: Propagate locally distributed prometheus and promtool binaries
   ansible.builtin.copy:

--- a/roles/prometheus/tasks/install.yml
+++ b/roles/prometheus/tasks/install.yml
@@ -77,11 +77,11 @@
     mode: 0755
     owner: root
     group: root
-    with_items:
-      - prometheus
-      - promtool
-    notify:
-      - restart prometheus
+  with_items:
+    - prometheus
+    - promtool
+  notify:
+    - restart prometheus
 
 - name: Propagate official console templates
   ansible.builtin.copy:
@@ -90,11 +90,11 @@
     mode: 0644
     owner: root
     group: root
-    with_items:
-      - console_libraries
-      - consoles
-    notify:
-      - restart prometheus
+  with_items:
+    - console_libraries
+    - consoles
+  notify:
+    - restart prometheus
 
 - name: Propagate locally distributed prometheus and promtool binaries
   ansible.builtin.copy:


### PR DESCRIPTION
… in the task is not enough to oeveride, this can lead to issues when passwordless sudo is not availible on the delegated local host machine